### PR TITLE
Another fix for a pivot control.

### DIFF
--- a/ScheduleBSUIR.WP8/MainPage.xaml.cs
+++ b/ScheduleBSUIR.WP8/MainPage.xaml.cs
@@ -98,41 +98,38 @@
                 Pivot pivot = sender as Pivot;
                 int nextSelectedIndex = pivot.SelectedIndex;
 
-                MainViewModel vm = App.ViewModel;
-                int baseIndex = vm.ShowedDays.Count;
-                int middle = baseIndex/2;
+                MainViewModel vmCopy = App.ViewModel;
+
+                int baseIndex = vmCopy.ShowedDays.Count;
                 int deltaMax = baseIndex - 1;
 
                 processingSelectionChange = true;
                 try
                 {
-                    int delta = pivot.SelectedIndex - vm.PreviousSelectedIndex;
+                    int delta = pivot.SelectedIndex - vmCopy.PreviousSelectedIndex;
                     if ((delta > 0 && delta != deltaMax) || delta == -deltaMax)
                     {
-                        vm.ShowedDays[nextSelectedIndex] = (DayViewModel) vm.ShowedDays[vm.PreviousSelectedIndex].Next();
+                        // going to the right
+                        vmCopy.ShowedDays[
+                            GetNormalizedIndex(vmCopy.PreviousSelectedIndex - 2, baseIndex)]
+                            .UpdateFrom(
+                            (DayViewModel)vmCopy.ShowedDays[
+                            GetNormalizedIndex(vmCopy.PreviousSelectedIndex + 2, baseIndex)]
+                            .Next());
                     }
                     else if ((delta < 0 && delta != -deltaMax) || delta == deltaMax)
                     {
-                        vm.ShowedDays[nextSelectedIndex] =
-                            (DayViewModel) vm.ShowedDays[vm.PreviousSelectedIndex].Previous();
+                        // going to the left
+                        vmCopy.ShowedDays[GetNormalizedIndex(vmCopy.PreviousSelectedIndex + 2, baseIndex)]
+                            .UpdateFrom(
+                            (DayViewModel)vmCopy.ShowedDays[GetNormalizedIndex(vmCopy.PreviousSelectedIndex - 2, baseIndex)]
+                            .Previous());
                     }
 
                     if (delta != 0)
                     {
-                        for (int i = 1; i <= middle; i++)
-                        {
-                            vm.ShowedDays[GetNormalizedIndex(nextSelectedIndex - i, baseIndex)] =
-                                (DayViewModel)
-                                    vm.ShowedDays[GetNormalizedIndex(nextSelectedIndex - i + 1, baseIndex)].Previous();
-
-                            vm.ShowedDays[GetNormalizedIndex(nextSelectedIndex + i, baseIndex)] =
-                                (DayViewModel)
-                                    vm.ShowedDays[GetNormalizedIndex(nextSelectedIndex + i - 1, baseIndex)].Next();
-                        }
-
-                        vm.SelectedDay = vm.ShowedDays[nextSelectedIndex];
-                        vm.PreviousSelectedIndex = nextSelectedIndex;
-                        vm.ShowedDays[nextSelectedIndex].UpdateContent();
+                        vmCopy.PreviousSelectedIndex = nextSelectedIndex;
+                        vmCopy.ShowedDays[nextSelectedIndex].UpdateContent();
                     }
                 }
                 finally

--- a/ScheduleBSUIR.WP8/Models/IScheduleService.cs
+++ b/ScheduleBSUIR.WP8/Models/IScheduleService.cs
@@ -3,9 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using ScheduleBSUIR.ViewModels;
-using ScheduleParser;
 
 namespace ScheduleBSUIR.Models
 {
@@ -16,6 +14,7 @@ namespace ScheduleBSUIR.Models
         DayViewModel Get(DateTime date);
 
         IEnumerable<DayViewModel> GetSequence(DateTime date, int number);
+
         void UpdateContent(DayViewModel dayViewModel);
     }
 }

--- a/ScheduleBSUIR.WP8/Properties/AssemblyInfo.cs
+++ b/ScheduleBSUIR.WP8/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using ScheduleBSUIR.Resources;
 //
 // Можно указать все значения или задать для номеров редакции и построения значения по умолчанию 
 // с помощью символа '*', как показано ниже:
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+[assembly: AssemblyVersion("1.0.3.1")]
+[assembly: AssemblyFileVersion("1.0.3.1")]
 [assembly: NeutralResourcesLanguageAttribute("en")]

--- a/ScheduleBSUIR.WP8/ViewModels/DayViewModel.cs
+++ b/ScheduleBSUIR.WP8/ViewModels/DayViewModel.cs
@@ -30,7 +30,7 @@ namespace ScheduleBSUIR.ViewModels
             get { return itemTitle; }
             set
             {
-                itemTitle = value;
+                itemTitle = TitleLengthHack( value );
                 NotifyPropertyChanged("ItemTitle");
             }
         }
@@ -48,6 +48,28 @@ namespace ScheduleBSUIR.ViewModels
         public void UpdateContent()
         {
             DaySchedule.UpdateContent(this);
+        }
+
+        public void UpdateFrom(DayViewModel d)
+        {
+            Subjects = d.Subjects;
+            ItemTitle = d.ItemTitle;
+            Date = d.Date;
+        }
+
+        /// <summary> Hack for a title width. </summary>
+        /// <param name="t"></param>
+        /// <returns>Constant width string.</returns>
+        private static string TitleLengthHack(string t)
+        {
+            const int titleWidth = 12;
+
+            if (t.Length < titleWidth)
+            {
+                return t + new string(' ', titleWidth - t.Length);
+            }
+
+            return t;
         }
     }
 }

--- a/ScheduleBSUIR.WP8/ViewModels/MainViewModel.cs
+++ b/ScheduleBSUIR.WP8/ViewModels/MainViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace ScheduleBSUIR.ViewModels
 {
@@ -8,7 +9,7 @@ namespace ScheduleBSUIR.ViewModels
     {
         private DayViewModel selectedDay;
         private ObservableCollection<DayViewModel> showedDays;
-        private int previousSelectedIndex;        
+        private int previousSelectedIndex;
 
         public DateTime CurrentDate
         {
@@ -21,21 +22,23 @@ namespace ScheduleBSUIR.ViewModels
         {
             IsDataLoaded = false;
 
-            ShowedDays = new ObservableCollection<DayViewModel>(days);
-            PreviousSelectedIndex = ShowedDays.Count / 2;
+            List<DayViewModel> daysList = days.ToList();
+
+            ShowedDays = new ObservableCollection<DayViewModel>(daysList.Skip(2).Concat(daysList.Take(2)));
+            PreviousSelectedIndex = 0;
             SelectedDay = ShowedDays[PreviousSelectedIndex];
             ShowedDays[PreviousSelectedIndex].UpdateContent();
 
-            IsDataLoaded = true;            
+            IsDataLoaded = true;
         }
-        
+
         public DayViewModel SelectedDay
         {
             get { return selectedDay; }
             set
             {
                 selectedDay = value;
-                NotifyPropertyChanged("SelectedDay");                
+                NotifyPropertyChanged("SelectedDay");
             }
         }
 
@@ -58,8 +61,8 @@ namespace ScheduleBSUIR.ViewModels
             set
             {
                 showedDays = value;
-                NotifyPropertyChanged("ShowedDays");                
+                NotifyPropertyChanged("ShowedDays");
             }
-        }       
+        }
     }
 }


### PR DESCRIPTION
Changed a data upadte process.

Performance should be better on a real device.

Contains a hack for pivot item header width. Now it is constant due to a problem with layout update on the fly. It has to be investigated later on.